### PR TITLE
Fix node version in function container

### DIFF
--- a/docker/functions/Dockerfile
+++ b/docker/functions/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14.17.5
+FROM node:10.0
 
 WORKDIR /usr/src/app
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
 * Fix node version inside docker image `function`

#### Motivation and Context
According to the output of `azure-functions-core-tools` only node versions 8.0 and 10.0 are supported.

#### How Has This Been Tested?
By running docker image locally through `yarn docker` in the repo root. 
Before the fix, the docker image would exit with an error.

#### Screenshots (if appropriate):
N/A

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.